### PR TITLE
Fix the build (remove import com.getcapacitor.Config)

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/intercom/IntercomPlugin.java
+++ b/android/src/main/java/com/getcapacitor/community/intercom/IntercomPlugin.java
@@ -1,6 +1,5 @@
 package com.getcapacitor.community.intercom;
 
-import com.getcapacitor.Config;
 import com.getcapacitor.NativePlugin;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;


### PR DESCRIPTION
By removing this line, the plugin works in capacitor 3

It fixes this error: 
```
> Task :capacitor-community-intercom:compileDebugJavaWithJavac FAILED
app/node_modules/@capacitor-community/intercom/android/src/main/java/com/getcapacitor/community/intercom/IntercomPlugin.java:3: error: cannot find symbol
import com.getcapacitor.Config;
                       ^
  symbol:   class Config
  location: package com.getcapacitor
Note: app/node_modules/@capacitor-community/intercom/android/src/main/java/com/getcapacitor/community/intercom/IntercomPlugin.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
1 error

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':capacitor-community-intercom:compileDebugJavaWithJavac'.
> Compilation failed; see the compiler error output for details.
```

Closes #26