### PR TITLE
Use the new Intercom.hide() method

### DIFF
--- a/ios/Plugin/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin/Plugin.swift
@@ -115,7 +115,7 @@ public class IntercomPlugin: CAPPlugin {
   }
   
   @objc func hideMessenger(_ call: CAPPluginCall) {
-    Intercom.hideMessenger()
+    Intercom.hide()
     call.success()
   }
   


### PR DESCRIPTION
Use Intercom.hide() method instead of the removed Intercom.hideMessenger().
This fixes XCode build error in projects that use intercom plugin.