### PR TITLE
FIX: displayMessageComposer can sen a message to the messenger

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/intercom/IntercomPlugin.java
+++ b/android/src/main/java/com/getcapacitor/community/intercom/IntercomPlugin.java
@@ -120,7 +120,8 @@ public class IntercomPlugin extends Plugin {
 
     @PluginMethod()
     public void displayMessageComposer(PluginCall call) {
-        Intercom.client().displayMessageComposer();
+        String message = call.getString("message");
+        Intercom.client().displayMessageComposer(message);
         call.success();
     }
 


### PR DESCRIPTION
After the plugin can't send  a message from the app to messenger, now displayMessageComposer() can send a message to the messenger in Intercom.