### PR TITLE
Handle user ids passed as integer

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/intercom/intercom/IntercomPlugin.java
+++ b/android/src/main/java/com/getcapacitor/community/intercom/intercom/IntercomPlugin.java
@@ -10,6 +10,8 @@ import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 import com.getcapacitor.annotation.Permission;
 
+import org.json.JSONException;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;

--- a/android/src/main/java/com/getcapacitor/community/intercom/intercom/IntercomPlugin.java
+++ b/android/src/main/java/com/getcapacitor/community/intercom/intercom/IntercomPlugin.java
@@ -49,7 +49,7 @@ public class IntercomPlugin extends Plugin {
     }
 
     @PluginMethod
-    public void registerIdentifiedUser(PluginCall call) {
+    public void registerIdentifiedUser(PluginCall call) throws JSONException {
         String email = call.getString("email");
         String userId = call.getData().get("userId").toString();
 

--- a/android/src/main/java/com/getcapacitor/community/intercom/intercom/IntercomPlugin.java
+++ b/android/src/main/java/com/getcapacitor/community/intercom/intercom/IntercomPlugin.java
@@ -51,7 +51,7 @@ public class IntercomPlugin extends Plugin {
     @PluginMethod
     public void registerIdentifiedUser(PluginCall call) {
         String email = call.getString("email");
-        String userId = call.getString("userId");
+        String userId = call.getData().get("userId").toString();
 
         Registration registration = new Registration();
 

--- a/ios/Plugin/IntercomPlugin.swift
+++ b/ios/Plugin/IntercomPlugin.swift
@@ -29,10 +29,10 @@ public class IntercomPlugin: CAPPlugin {
     let email = call.getString("email")
 
     if (userId != nil && email != nil) {
-        Intercom.registerUser(withUserId: userId! as! String, email: email!)
+        Intercom.registerUser(withUserId: String(describing: userId), email: email!)
       call.resolve()
     }else if (userId != nil) {
-        Intercom.registerUser(withUserId: userId! as! String)
+        Intercom.registerUser(withUserId: String(describing: userId))
       call.resolve()
     }else if (email != nil) {
       Intercom.registerUser(withEmail: email!)

--- a/ios/Plugin/IntercomPlugin.swift
+++ b/ios/Plugin/IntercomPlugin.swift
@@ -25,14 +25,14 @@ public class IntercomPlugin: CAPPlugin {
   }
 
   @objc func registerIdentifiedUser(_ call: CAPPluginCall) {
-    let userId = call.getString("userId")
+    let userId = call.getAny("userId")
     let email = call.getString("email")
 
     if (userId != nil && email != nil) {
-      Intercom.registerUser(withUserId: userId!, email: email!)
+        Intercom.registerUser(withUserId: userId! as! String, email: email!)
       call.resolve()
     }else if (userId != nil) {
-      Intercom.registerUser(withUserId: userId!)
+        Intercom.registerUser(withUserId: userId! as! String)
       call.resolve()
     }else if (email != nil) {
       Intercom.registerUser(withEmail: email!)
@@ -172,3 +172,4 @@ public class IntercomPlugin: CAPPlugin {
       }
   }
 }
+


### PR DESCRIPTION
In some cases the `userId` can be of type `integer`, and in this case `call.getString("userId")` returns an empty `string` and the user is not registered so this case needs to be handled