### PR TITLE
Bug - Android - not providing a userId throws an Exception

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/intercom/intercom/IntercomPlugin.java
+++ b/android/src/main/java/com/getcapacitor/community/intercom/intercom/IntercomPlugin.java
@@ -51,9 +51,9 @@ public class IntercomPlugin extends Plugin {
     }
 
     @PluginMethod
-    public void registerIdentifiedUser(PluginCall call) throws JSONException {
+    public void registerIdentifiedUser(PluginCall call) {
         String email = call.getString("email");
-        String userId = call.getData().get("userId").toString();
+        String userId = call.getData().getString("userId");
 
         Registration registration = new Registration();
 


### PR DESCRIPTION
Hi,

As per the documentation, it should be possible to only pass in an email field without providing a userId. A change that was introduced in #68 now throws an Exception if the userId is not passed in. This was a breaking change that probably shouldn't have been pushed through.

This PR replaces the "get" call, which throws JSONException when the key doesn't exist, with the null fallback version "getString". As per the JSONObject this particular call will coerce the value to a String if necessary, so should still handle the original use case of an Integer id.

Thanks.