### PR TITLE
fix: pin Intercom pod version

### DIFF
--- a/CapacitorCommunityIntercom.podspec
+++ b/CapacitorCommunityIntercom.podspec
@@ -13,6 +13,6 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target  = '13.0'
   s.dependency 'Capacitor'
-  s.dependency 'Intercom'
+  s.dependency 'Intercom', '15.2.1'
   s.swift_version = '5.1'
 end


### PR DESCRIPTION
When a Capacitor plugin relies on a specific iOS pod, it should specify the pod version to be sure the pod code used by the Capacitor plugin code matches.

You can see an example in the Facebook Login Capacitor plugin [here](https://github.com/capacitor-community/facebook-login/blob/9a5d683d7c12beacdcd5f4e7e19e7860fcacde84/CapacitorCommunityFacebookLogin.podspec#L18).

Fixes #96