### PR TITLE
refactor(android)!: remove firebase dependency

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -57,5 +57,4 @@ dependencies {
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
     implementation "io.intercom.android:intercom-sdk:$intercomSdkVersion"
-    implementation 'com.google.firebase:firebase-messaging:20.2.+'
 }


### PR DESCRIPTION
The plugin doesn't use any firebase code so the plugin shouldn't include the dependency. Despite the users might want to send the firebase token to intercom, they should use another plugin for getting the token and that plugin would have a firebase dependency.

Setting it as breaking change as some users might be relying in having firebase installed by this plugin.