### PR TITLE
fix(ios): Pin intercom version to 16.x

### DIFF
--- a/CapacitorCommunityIntercom.podspec
+++ b/CapacitorCommunityIntercom.podspec
@@ -13,6 +13,6 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target  = '13.0'
   s.dependency 'Capacitor'
-  s.dependency 'Intercom'
+  s.dependency 'Intercom', '~> 16.0'
   s.swift_version = '5.1'
 end


### PR DESCRIPTION
Intercom 17 requires iOS 14, Intercom 18 requires iOS 15, the plugin supports iOS 13+, so the dependencies fail to install because of that.
This PR pins the intercom version to 16.x so it installs the dependencies correctly.